### PR TITLE
Changed storing of backups to prefixed file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 settings_local.ini
+.env

--- a/cloudkeys/Ajax/Handler.php
+++ b/cloudkeys/Ajax/Handler.php
@@ -43,7 +43,7 @@ class AjaxHandler extends BaseHttpHandler {
     }
 
     try {
-      S3::copyObject($this->config->get('AWSS3Bucket'), $userfile, $this->config->get('AWSS3Bucket'), $userfile . '.' . idate('U') . '.backup');
+      S3::copyObject($this->config->get('AWSS3Bucket'), $userfile, $this->config->get('AWSS3Bucket'), 'backup/' . $userfile . '.' . idate('U'));
       $data['metadata']['version'] = $this->request->get('checksum');
       $data['data'] = $this->request->get('data');
       S3::putObject(json_encode($data), $this->config->get('AWSS3Bucket'), $userfile);

--- a/index.php
+++ b/index.php
@@ -5,6 +5,7 @@ require_once 'lib/framework/dispatcher.php';
 // BaseAutoLoader::register_base_lib('mysql');
 // BaseAutoLoader::register_base_lib('couchdb');
 BaseAutoLoader::register_base_lib('cloudcontrol');
+BaseAutoLoader::register_base_lib('heroku');
 BaseAutoLoader::register_library_path(dirname(__FILE__) . '/lib/s3');
 
 if(file_exists('cloudkeys/settings_local.ini')) {
@@ -12,6 +13,10 @@ if(file_exists('cloudkeys/settings_local.ini')) {
 } else {
   $config = new ConfigIni('cloudkeys/settings.ini', null);
 }
+
+// Wrap config store to enable reading Heroku ENV vars
+$config = new HerokuConfigStore($config);
+
 S3::setAuth($config->get('AWSAccessKey'), $config->get('AWSSecretKey'));
 S3::setExceptions(true);
 


### PR DESCRIPTION
This enables the owner of the bucket to set an expiration policy for
prefix `backup/` and have backups deleted time X after creation.
Otherwise the backups are cluttering the bucket and have to be cleaned
manually.
